### PR TITLE
add customer and orders models

### DIFF
--- a/models/marts/_marts__models.yml
+++ b/models/marts/_marts__models.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: customers
+  - name: orders

--- a/models/marts/customers.sql
+++ b/models/marts/customers.sql
@@ -1,0 +1,61 @@
+with
+
+customers as (
+
+    select * from {{ ref('stg_tech_store__customers') }}
+
+),
+
+cities as (
+
+    select * from {{ ref('stg_tech_store__cities') }}
+
+),
+
+states as (
+
+    select * from {{ ref('stg_tech_store__states') }}
+
+),
+
+zip_codes as (
+
+    select * from {{ ref('stg_tech_store__zip_codes') }}
+
+),
+
+employees as (
+
+    select * from {{ ref('stg_tech_store__employees') }}
+
+),
+
+final as (
+
+    select
+        customers.customer_id,
+        customers.customer_name,
+        cities.city_name,
+        states.state_name,
+        zip_codes.zip_code,
+        employees.full_name as main_employee,
+        customers.created_at,
+        customers.updated_at,
+        customers.is_active
+
+    from customers
+
+    left join cities
+        on customers.city_id = cities.city_id
+
+    left join states
+        on cities.state_id = states.state_id
+
+    left join zip_codes
+        on cities.zip_code_id = zip_codes.zip_code_id
+
+    left join employees
+        on customers.main_employee_id = employees.employee_id
+)
+
+select * from final

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -1,0 +1,59 @@
+with
+
+orders as (
+
+    select * from {{ ref('stg_tech_store__orders') }}
+
+),
+
+transactions as (
+
+    select * from {{ ref('stg_payment_app__transactions') }}
+
+),
+
+products as (
+
+    select * from {{ ref('stg_tech_store__products') }}
+
+),
+
+customers as (
+
+    select * from {{ ref('stg_tech_store__customers') }}
+
+),
+
+
+final as (
+
+    select
+        orders.order_id,
+        transactions.transaction_id,
+        customers.customer_id,
+        customers.customer_name,
+        products.product_name,
+        products.category,
+        products.price,
+        products.currency,
+        orders.quantity,        
+        transactions.cost_per_unit_in_usd,
+        transactions.amount_in_usd,
+        transactions.tax_in_usd,
+        transactions.total_charged_in_usd,
+        orders.created_at
+
+    from orders
+
+    left join transactions
+        on orders.order_id = transactions.order_id
+
+    left join products
+        on orders.product_id = products.product_id
+
+    left join customers
+        on orders.customer_id = customers.customer_id
+
+)
+
+select * from final


### PR DESCRIPTION
### Summary
Add 2 new `marts` models for `customers` and `orders`

### Details
Creating more detailed `marts` models for end user Analytics.
* `customers` - Provide a full view of all `customer`-level information
* `orders` - Provide a full view of `order`-level information along with `product,` `customer` and `transaction` data

Set `+materialized: table` in `dbt_project.yml` for `marts`

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
* [dbt Best Practices - Marts](https://docs.getdbt.com/guides/best-practices/how-we-structure/4-marts)